### PR TITLE
Change Ktor engine to WinHttp for mingwX64

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,13 +49,7 @@ kotlin {
         }
     }
 
-    mingwX64().apply {
-        compilations.forEach { compilation ->
-            compilation.kotlinOptions.freeCompilerArgs = mutableListOf(
-                "-linker-options", "-L${System.getenv("MINGWX64_HOME")}\\lib"
-            )
-        }
-
+    mingwX64 {
         binaries {
             executable {
                 baseName = buildString {
@@ -92,8 +86,8 @@ kotlin {
             implementation(libs.sl4j.simple)
         }
 
-        nativeMain.get().dependencies {
-            implementation(libs.ktor.client.curl)
+        mingwMain.get().dependencies {
+            implementation(libs.ktor.client.winhttp)
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-curl = { module = "io.ktor:ktor-client-curl", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
+ktor-client-winhttp = { module = "io.ktor:ktor-client-winhttp", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 sl4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "sj4j" }
 

--- a/src/mingwX64Main/kotlin/cz/drekorian/avonmobilefetcher/http/KtorHttpClient.kt
+++ b/src/mingwX64Main/kotlin/cz/drekorian/avonmobilefetcher/http/KtorHttpClient.kt
@@ -2,6 +2,6 @@ package cz.drekorian.avonmobilefetcher.http
 
 import io.ktor.client.engine.HttpClientEngineConfig
 import io.ktor.client.engine.HttpClientEngineFactory
-import io.ktor.client.engine.curl.Curl
+import io.ktor.client.engine.winhttp.WinHttp
 
-internal actual val engineConfig: HttpClientEngineFactory<HttpClientEngineConfig> = Curl
+internal actual val engineConfig: HttpClientEngineFactory<HttpClientEngineConfig> = WinHttp


### PR DESCRIPTION
Changes Ktor engine to `WinHttp` for `mingwX64`.